### PR TITLE
Fix function Initialize-ModList: Literal-Path

### DIFF
--- a/Arma3SSPSL/scripts/functions.ps1
+++ b/Arma3SSPSL/scripts/functions.ps1
@@ -498,7 +498,7 @@ function Initialize-ModList
         $relativePath = "!Workshop\@$mod"
         $absolutePath = Join-Path $a3RootPath $relativePath
 
-        if (Test-Path $absolutePath)
+        if (Test-Path -LiteralPath $absolutePath)
         {
             if ($ServerMods)
             {


### PR DESCRIPTION
Add parameter -Literal-Path to Test-Path invoke (line 501) to correct special characters processing( tested with square brakets in mod name).